### PR TITLE
Create initial testing framework

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,40 @@
+version: "2"
+exclude_patterns:
+- "doc/"
+- "dist/"
+- "tests/"
+checks:
+  argument-count:
+    config:
+      threshold: 10
+  complex-logic:
+    config:
+      threshold: 20
+  file-lines:
+    enabled: false
+  method-complexity:
+    config:
+      threshold: 20
+  method-count:
+    config:
+      threshold: 75
+  method-lines:
+    config:
+      threshold: 100
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 4
+  similar-code:
+    config:
+      threshold: 64
+  identical-code:
+    config:
+      threshold: 64
+plugins:
+  fixme:
+    enabled: true
+  pep8:
+    enabled: true

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = src
+
+[report]
+exclude_lines =
+    # Skip Python wrappers which help load in C extension modules.
+    __bootstrap__()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,92 @@
+# The name is short because we mostly care how it appears in the pull request
+# "checks" dialogue box - it looks like
+#     Tests / ubuntu-latest, python-3.9, defaults
+# or similar.
+name: Tests
+
+on:
+    [push, pull_request]
+
+defaults:
+  run:
+    # The slightly odd shell call is to force bash to read .bashrc, which is
+    # necessary for having conda behave sensibly.  We use bash as the shell even
+    # on Windows, since we don't run anything much complicated, and it makes
+    # things much simpler.
+    shell: bash -l {0}
+
+jobs:
+  cases:
+    name: ${{ matrix.os }}, ${{ matrix.case-name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.9]
+        case-name: [defaults]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install QuTiP from GitHub
+        run: |
+          python -mpip install git+https://github.com/qutip/qutip.git@dev.major
+          python -c 'import qutip; qutip.about()'
+
+      - name: Install qutip-tensorflow and dependencies
+        # Install in editable mode so Coveralls detects the tree structure
+        # relative to the git repository root as well.
+        run: |
+            python -mpip install -e .[full]
+            python -mpip install pytest-cov coveralls
+
+      - name: Package information
+        run: |
+          conda list
+          python -c 'import qutip_tensorflow; print(qutip_tensorflow.__version__)'
+
+      - name: Run tests
+        # If our tests are running for longer than an hour, _something_ is wrong
+        # somewhere.  The GitHub default is 6 hours, which is a bit long to wait
+        # to see if something hung.
+        timeout-minutes: 60
+        run: |
+          pytest --durations=0 --durations-min=1.0 --verbosity=1 --cov=qutip_tensorflow --color=yes
+          # Above flags are:
+          #  --durations=0 --durations-min=1.0
+          #     at the end, show a list of all the tests that took longer than a
+          #     second to run
+          #  --verbosity=1
+          #     turn the verbosity up so pytest prints the names of the tests
+          #     it's currently working on
+          #  --cov=qutip_tensorflow
+          #     limit coverage reporting to code that's within the qutip_tensorflow package
+          #  --color=yes
+          #     force coloured output in the terminal
+          # These flags are added to those in pyproject.toml.
+
+      - name: Upload to Coveralls
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+          COVERALLS_FLAG_NAME: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.case-name }}
+          COVERALLS_PARALLEL: true
+        run: coveralls --service=github
+
+  finalise:
+    name: Finalise coverage reporting
+    needs: cases
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+      - name: Finalise coverage reporting
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        run: |
+          python -mpip install coveralls
+          coveralls --service=github --finish

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include VERSION
+recursive-include tests *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,9 @@ requires = [
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "-Werror --strict-config --strict-markers"
+testpaths = [
+    "tests",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,3 +34,9 @@ setup_requires =
 
 [options.packages.find]
 where = src
+
+[options.extras_require]
+tests =
+    pytest>=6.0
+full =
+    %(tests)s

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,6 @@
+# This is a dummy test file; delete it once the package actually has tests.
+
+
+def test_import():
+    import qutip_tensorflow
+    assert qutip_tensorflow.__version__


### PR DESCRIPTION
This sets up a basic pytest framework for automatically testing the package, a GitHub Action to automatically run these tests on every push and pull request sync, and configuration files for Coveralls (included in the action) and CodeClimate.  These are quite similar to the current main QuTiP versions, except we have to handle manual installation of QuTiP from GitHub on a different branch.

@AGaliciaMartinez: don't feel like you have to speed through reviewing this (there's one more to come after as well) - the coding period hasn't officially started yet - so just whenever you've got some time.  If you've got points you disagree with as well, don't feel like you have to accept the PR immediately - there's no hurry, and plenty of time to discuss and potentially make changes.