### PR TITLE
Correct QuTiP version specifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir =
 packages = find:
 include_package_data = True
 install_requires =
-    qutip>=5.0.0.a0
+    qutip>=5.0.0.dev0
 setup_requires =
     packaging
 


### PR DESCRIPTION
QuTiP installs failed because `5.0.0dev0` is "lower" than `5.0.0a0`.  This was a bug in the configuration file that was able to slip through because `dev.major` was still using an old versioning scheme.