### PR TITLE
Benchmark axes label

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -53,9 +53,9 @@ def plot_benchmark(df, destination_folder):
         plt.legend()
         plt.yscale('log')
         plt.xscale('log')
-        plt.savefig(f".benchmarks/figures/{operation}_{density}.png")
         plt.xlabel("N")
-        plt.ylabel("t(s)")
+        plt.ylabel("time (s)")
+        plt.savefig(f".benchmarks/figures/{operation}_{density}.png")
         plt.close()
 
 

--- a/tests/test_linear_algebra.py
+++ b/tests/test_linear_algebra.py
@@ -62,8 +62,9 @@ def change_dtype(A, dtype):
         return A.to(dtype)
 
 #Supported dtypes
-dtype_list = [np, tf, sc, qt.data.Dense, qt.data.CSR]
-dtype_ids = ['numpy', 'tensorflow', 'scipy_CSR', 'qutip_Dense', 'qutip_CSR']
+dtype_list = [np, tf, sc, qt.data.Dense, qt.data.CSR, qtf.data.TfTensor]
+dtype_ids = ['numpy', 'tensorflow', 'scipy_csr', 'qutip_dense', 'qutip_csr',
+             'qutip_tftensor']
 @pytest.fixture(params = dtype_list, ids=dtype_ids)
 def dtype(request): return request.param
 

--- a/tests/test_linear_algebra.py
+++ b/tests/test_linear_algebra.py
@@ -63,7 +63,7 @@ def change_dtype(A, dtype):
 
 #Supported dtypes
 dtype_list = [np, tf, sc, qt.data.Dense, qt.data.CSR]
-dtype_ids = ['numpy', 'tensorflow', 'scipy(CSR)', 'qutip(Dense)', 'qutip(CSR)']
+dtype_ids = ['numpy', 'tensorflow', 'scipy-CSR', 'qutip-Dense', 'qutip-CSR']
 @pytest.fixture(params = dtype_list, ids=dtype_ids)
 def dtype(request): return request.param
 

--- a/tests/test_linear_algebra.py
+++ b/tests/test_linear_algebra.py
@@ -63,7 +63,7 @@ def change_dtype(A, dtype):
 
 #Supported dtypes
 dtype_list = [np, tf, sc, qt.data.Dense, qt.data.CSR]
-dtype_ids = ['numpy', 'tensorflow', 'scipy-CSR', 'qutip-Dense', 'qutip-CSR']
+dtype_ids = ['numpy', 'tensorflow', 'scipy_CSR', 'qutip_Dense', 'qutip_CSR']
 @pytest.fixture(params = dtype_list, ids=dtype_ids)
 def dtype(request): return request.param
 

--- a/tests/test_linear_algebra.py
+++ b/tests/test_linear_algebra.py
@@ -9,10 +9,11 @@ import warnings
 from . import benchmark_unary
 from . import benchmark_binary
 
-
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import tensorflow as tf
+
+import qutip_tensorflow as qtf
 
 # Get functions from unary ops that stater with `get`
 unary_ops = [ getattr(benchmark_unary,_) for _ in dir(benchmark_unary) if _[:3]=="get"]


### PR DESCRIPTION
- Include axes labels in benchmarks plots.
- Included qutip_tensorflow in benchmarks
- changed id for data types to be easier to filter them (it was not possible to do use the argument `-k"qutip(Dense)"` due to the parenthesis).