### PR TITLE
Bug: Pow specialisation was being added to expm dispatcher.

### DIFF
--- a/src/qutip_tensorflow/core/data/pow.py
+++ b/src/qutip_tensorflow/core/data/pow.py
@@ -34,7 +34,7 @@ def pow_tftensor(matrix, n):
     return TfTensor._fast_constructor(out, shape=matrix.shape)
 
 
-qutip.data.expm.add_specialisations(
+qutip.data.pow.add_specialisations(
     [
         (TfTensor, TfTensor, pow_tftensor),
     ]


### PR DESCRIPTION
I really think that adding an assert in the Tests for the specialisations that checks whether the tested specialisation have been added correctly would prevent this kind of mistakes. It would only have to check whether the `_specialisations` attribute has the new specialisation that is being tested. 