### PR TITLE
Fixed colab badge not working.

### DIFF
--- a/examples/rotation_optimization.ipynb
+++ b/examples/rotation_optimization.ipynb
@@ -5,7 +5,7 @@
    "id": "7fc98e06",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/qutip/qutip-tensorflow/examples/rotation_optimization.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/qutip/qutip-tensorflow/blob/main/examples/rotation_optimization.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
Quick fix for the colab badge in the example notebook. It was not pointing correctly to the master branch. 