### PR TITLE
Changed default dtype of TfTensor to be stored as complex64

### DIFF
--- a/src/qutip_tensorflow/core/data/pow.py
+++ b/src/qutip_tensorflow/core/data/pow.py
@@ -18,7 +18,7 @@ def pow_tftensor(matrix, n):
                          matrix has shape={matrix.shape}"""
         )
 
-    out = tf.eye(matrix.shape[0], matrix.shape[1], dtype=tf.complex128)
+    out = tf.eye(matrix.shape[0], matrix.shape[1], dtype=tf.complex64)
     pow = matrix._tf
 
     out = pow if n & 1 else out

--- a/src/qutip_tensorflow/core/data/tftensor.py
+++ b/src/qutip_tensorflow/core/data/tftensor.py
@@ -31,7 +31,7 @@ class TfTensor(qutip.core.data.Data):
 
         # If dtype of Tensor is already a tf.complex128 then this will not
         # return a copy
-        data = tf.cast(data, tf.complex128)
+        data = tf.cast(data, tf.complex64)
 
         # Inherit shape from data and expand shape
         if shape is None:
@@ -95,7 +95,7 @@ class TfTensor(qutip.core.data.Data):
         """
         A fast low-level constructor for wrapping an existing Tensor array in a
         TfTensor object without copying it. The ``data`` argument must be a
-        Tensor array with the correct shape.
+        Tensor array with the correct shape and dtype.
         """
         out = cls.__new__(cls)
         super(cls, out).__init__(shape)

--- a/tests/core/data/conftest.py
+++ b/tests/core/data/conftest.py
@@ -12,6 +12,7 @@ from qutip_tensorflow.core.data import TfTensor
 def random_numpy_dense(shape, fortran):
     """Generate a random numpy dense matrix with the given shape."""
     out = np.random.rand(*shape) + 1j * np.random.rand(*shape)
+    out = out.astype(np.complex64)
     if fortran:
         out = np.asfortranarray(out)
     return out
@@ -21,6 +22,7 @@ def random_tensor_dense(shape):
     """Generate a random `Tensor` dense matrix with the given shape."""
     out = np.random.rand(*shape) + 1j * np.random.rand(*shape)
     out = tf.constant(out)
+    out = tf.cast(out, dtype=tf.complex64)
     return out
 
 

--- a/tests/core/data/test_mathematics.py
+++ b/tests/core/data/test_mathematics.py
@@ -26,6 +26,8 @@ testing._ALL_CASES = {
 }
 testing._RANDOM = {TfTensor: lambda shape: [lambda: conftest.random_tftensor(shape)]}
 
+print('hi')
+
 
 class TestAdd(testing.TestAdd):
     specialisations = [
@@ -59,24 +61,28 @@ class TestTranspose(testing.TestTranspose):
 
 
 class TestInner(testing.TestInner):
+    tol = 1e-3
     specialisations = [
         pytest.param(data.inner_tftensor, TfTensor, TfTensor, tf.Tensor),
     ]
 
 
 class TestInnerOp(testing.TestInnerOp):
+    tol = 1e-3
     specialisations = [
         pytest.param(data.inner_op_tftensor, TfTensor, TfTensor, TfTensor, tf.Tensor),
     ]
 
 
 class TestTrace(testing.TestTrace):
+    tol = 1e-5
     specialisations = [
         pytest.param(data.trace_tftensor, TfTensor, tf.Tensor),
     ]
 
 
 class TestKron(testing.TestKron):
+    tol = 1e-5
     specialisations = [
         pytest.param(data.kron_tftensor, TfTensor, TfTensor, TfTensor),
     ]
@@ -90,12 +96,14 @@ class TestMul(testing.TestMul):
 
 
 class TestMatmul(testing.TestMatmul):
+    tol = 1e-4
     specialisations = [
         pytest.param(data.matmul_tftensor, TfTensor, TfTensor, TfTensor),
     ]
 
 
 class TestNeg(testing.TestNeg):
+
     specialisations = [
         pytest.param(data.neg_tftensor, TfTensor, TfTensor),
     ]
@@ -125,60 +133,73 @@ class TestColumnStack(TestColumnStack):
     ]
 
 class TestExpect(TestExpect):
+    tol = 1e-3
     specialisations = [
         pytest.param(data.expect_tftensor, TfTensor, TfTensor, tf.Tensor),
     ]
 
 
 class TestExpectSuper(TestExpectSuper):
+    tol = 1e-4
     specialisations = [
         pytest.param(data.expect_super_tftensor, TfTensor, TfTensor, tf.Tensor),
     ]
-    
-      
+
+
 class TestExpm(testing.TestExpm):
+    tol = 1e-5
     specialisations = [
         pytest.param(data.expm_tftensor, TfTensor, TfTensor),
     ]
 
 
 class TestPow(testing.TestPow):
+    rtol = 1e-4
     specialisations = [
         pytest.param(data.pow_tftensor, TfTensor, TfTensor),
     ]
 
 
 class TestProject(testing.TestProject):
+    tol = 1e-5
     specialisations = [
         pytest.param(data.project_tftensor, TfTensor, TfTensor),
     ]
 
 
 class TestTraceNorm(TestTraceNorm):
+    # this one needs larger tol because the output is larger in magnitude and
+    # tol refers to absolute tolerance. This suggest that we may want to use
+    # a relative tol instead.
+    tol = 1e-2
     specialisations = [
         pytest.param(data.norm.trace_tftensor, TfTensor, tf.Tensor),
     ]
 
 
 class TestOneNorm(TestOneNorm):
+    tol = 1e-4
     specialisations = [
         pytest.param(data.norm.one_tftensor, TfTensor, tf.Tensor),
     ]
 
 
 class TestL2Norm(TestL2Norm):
+    tol = 1e-5
     specialisations = [
         pytest.param(data.norm.l2_tftensor, TfTensor, tf.Tensor),
     ]
 
 
 class TestMaxNorm(TestMaxNorm):
+    tol = 1e-5
     specialisations = [
         pytest.param(data.norm.max_tftensor, TfTensor, tf.Tensor),
     ]
 
 
 class TestFrobeniusNorm(TestFrobeniusNorm):
+    tol = 1e-5
     specialisations = [
         pytest.param(data.norm.frobenius_tftensor, TfTensor, tf.Tensor),
     ]

--- a/tests/core/data/test_tftensor.py
+++ b/tests/core/data/test_tftensor.py
@@ -95,7 +95,7 @@ class TestClassMethods:
         _list_dense = _numpy_dense.tolist()
         test = TfTensor(_list_dense)
         assert test.shape == shape
-        assert test._tf.dtype == tf.complex128
+        assert test._tf.dtype == tf.complex64
         assert test._tf.shape == shape
         assert_almost_equal(test.to_array(), _list_dense)
 
@@ -106,8 +106,9 @@ class TestClassMethods:
         _numpy_dense = np.random.rand(*shape).astype(dtype, casting="unsafe")
         test = TfTensor(_numpy_dense)
         assert test.shape == shape
-        assert test._tf.dtype == tf.complex128
+        assert test._tf.dtype == tf.complex64
         assert test._tf.shape == shape
+        _numpy_dense = _numpy_dense.astype(np.complex64)
         assert np.all(test.to_array() == _numpy_dense)
 
     @pytest.mark.parametrize(
@@ -119,9 +120,9 @@ class TestClassMethods:
         test = TfTensor(tensor)
         assert test.shape == shape
         assert test._tf.shape == shape
-        assert test._tf.dtype == tf.complex128
+        assert test._tf.dtype == tf.complex64
 
-        tensor = tf.cast(tensor, dtype=tf.complex128)
+        tensor = tf.cast(tensor, dtype=tf.complex64)
         assert np.all(test._tf == tensor)
 
     @pytest.mark.parametrize(
@@ -154,7 +155,7 @@ class TestClassMethods:
 
     @pytest.mark.parametrize("copy", [True, False])
     def test_init_copy(self, copy, tensor_dense):
-        """Test that copy argument in __init__ work as intended."""
+        """Test that copy argument in __init__ works as intended."""
         test = TfTensor(tensor_dense, copy=copy)
         assert test.shape == tuple(tensor_dense.shape.as_list())
         assert np.all(test.to_array() == tensor_dense)


### PR DESCRIPTION
Complex 128 seems to not benefit from any improvement in operation performance when using a GPU. This is because GPUs are optimized to work with float32 numbers. Hence, if any improvement in performance is expected to be gained from using a GPU, we would need to change the default dtype to complex64. For an example of such improvements doing 100 matmul with matrices of size 2^10x2^10:

| backend| dtype | time (mean ± std. dev. of 7 runs, 1 loop each )|
|--------|-----|-------------|
|numpy | complex128|895 ms ± 88.6 ms per loop|
|qutip_dense | complex128|826 ms ± 12 ms per loop|
|qutip_tftensor | complex128 (GPU)|1450 ms ± 2.01 ms per loop|
|numpy | complex64|416 ms ± 16.9 ms per loop |
|qutip_tftensor | complex64 (GPU)|51 ms ± 628 µs per loop|

Notice that for complex128 qutip_tftensor is _x2 slower_ that numpy but for complex64 qutip_tftensor is _x8 times faster_ than numpy with the same dtype.

Another option, instead of this implementation, is to add tftensor64 and tftensor128 so that it is still possible to benefit from the autodifferentiation while keeping the precision (would be useful to use when working with a CPU).

Benchmark code (for qutip_tftensor I manually changed the casting rule in `tftensor.py`):
```python
import tensorflow as tf
import numpy as np
import qutip
import qutip_tensorflow as qtf

random_np = np.random.random((2**10,2**10)) + 1j*np.random.random((2**10,2**10))
rep = 20
np_128 = random_np.astype(np.complex128)
np_64 = random_np.astype(np.complex64)
qobj = qutip.Qobj(random_np)
qobj_tf = qobj.to('tftensor')

# Numpy with complex128
%%timeit
for i in range(rep):
    _ = np_128@np_128

# Numpy with complex64
%%timeit
for i in range(rep):
    _ = np_64@np_64

# qutip_dense with complex128
%%timeit
for i in range(rep):
    _ = qobj@qobj

# qutip_tftensor with complex64 if using this branch or complex128 if using main
%%timeit
_ = qobj_tf
for i in range(rep):
    _ = _@qobj_tf
_.data._tf.numpy() # synchronize GPU
```
The benchmark uses a GPU 970 GTX  and an intel-i7 6700.

TODO:
- [ ] If this change is going to be merged it should be explicitly be addressed in the README explaining clearly why the change in precision is necessary and the potential drawbacks it may have.
- [ ] For the tests to work with complex64 I need to change the relative tolerance of some numerical comparisons. This is specially important for the tests that address `pow` and `expm`. This has to be added on qutip@dev.major.
